### PR TITLE
[Parvathy, Rahul] | BAH-3193 | Add. Latest Stable Packages For Security

### DIFF
--- a/hip-atomfeed/pom.xml
+++ b/hip-atomfeed/pom.xml
@@ -32,11 +32,11 @@
         <atomfeed.version>1.10.1</atomfeed.version>
         <hapi-base.version>2.2</hapi-base.version>
         <spring.profiles.active>local,no-liquibase</spring.profiles.active>
-        <quartz.version>2.2.1</quartz.version>
+        <quartz.version>2.4.0-rc1</quartz.version>
         <postgresql.version>42.5.0</postgresql.version>
         <hsqldb.version>2.7.1</hsqldb.version>
         <web-clients.version>0.94.3</web-clients.version>
-        <httpclient.version>4.5</httpclient.version>
+        <httpclient.version>4.5.13</httpclient.version>
         <commons-io.version>2.7</commons-io.version>
         <liquibase.version>4.9.0</liquibase.version>
         <liquibase-slf4j.version>1.0.0</liquibase-slf4j.version>
@@ -209,6 +209,11 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
             <version>${log4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>2.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.15</version>
     </parent>
 
     <modules>
@@ -35,10 +35,6 @@
                     <from>
                         <image>amazoncorretto:8</image>
                         <platforms>
-                            <platform>
-                                <architecture>amd64</architecture>
-                                <os>linux</os>
-                            </platform>
                             <platform>
                                 <architecture>arm64</architecture>
                                 <os>linux</os>


### PR DESCRIPTION
In this PR, the following modifications have been implemented:

spring-boot-starter-parent Update: The org.springframework.boot:spring-boot-starter-parent has been upgraded from version jre-2.7.6 to 2.7.15.
Dependency Update: A few dependencies have been updated to their immediate stable versions.

This would fix most of our vulnerabilities except the following :
<img width="1532" alt="Screenshot 2023-08-31 at 4 44 35 PM" src="https://github.com/BahmniIndiaDistro/hip-atomfeed-listener/assets/121226043/6fa79df1-940f-4411-a12e-c631bd5eb86a">
There is no direct fix for the above vulnerabilities and further investigation needs to be done for the above vulnerabilities.